### PR TITLE
Simipify waveform syntehsis interface

### DIFF
--- a/examples/compare_vocoders.jl
+++ b/examples/compare_vocoders.jl
@@ -49,9 +49,7 @@ xw .*= win
 function test_poledf_synthesis(; order=25, savepath="test16k_poledf.wav")
     println("testing: poledf_synthesis")
     l = estimate(LinearPredictionCoef(order), xw, use_mgcep=true)
-
-    f = AllPoleDF(order)
-    y = synthesis!(f, base_excitation, l, hopsize)
+    y = synthesis(base_excitation, l, hopsize)
     wavwrite(y, savepath; Fs=fs)
     println("Dumped to $savepath")
 end
@@ -59,9 +57,7 @@ end
 function test_ltcdf_synthesis(; order=25, savepath="test16k_ltcdf.wav")
     println("testing: ltcdf_synthesis")
     par = lpc2par(estimate(LinearPredictionCoef(order), xw, use_mgcep=true))
-
-    f = AllPoleLatticeDF(order)
-    y = synthesis!(f, base_excitation, par, hopsize)
+    y = synthesis(base_excitation, par, hopsize)
     wavwrite(y, savepath; Fs=fs)
     println("Dumped to $savepath")
 end
@@ -69,9 +65,7 @@ end
 function test_lspdf_synthesis(; order=20, savepath="test16k_lspdf.wav")
     println("testing: lspdf_synthesis")
     l = lpc2lsp(estimate(LinearPredictionCoef(order), xw, use_mgcep=true))
-
-    f = LSPDF(order)
-    y = synthesis!(f, base_excitation, l, hopsize)
+    y = synthesis(base_excitation, l, hopsize)
     wavwrite(y, savepath; Fs=fs)
     println("Dumped to $savepath")
 end
@@ -79,9 +73,7 @@ end
 function test_lmadf_synthesis(; order=25, savepath="test16k_lmadf.wav")
     println("testing: lmadf_synthesis")
     c = estimate(LinearCepstrum(order), xw)
-
-    f = LMADF(order)
-    y = synthesis!(f, base_excitation, c, hopsize)
+    y = synthesis(base_excitation, c, hopsize)
     wavwrite(y, savepath; Fs=fs)
     println("Dumped to $savepath")
 end
@@ -90,9 +82,7 @@ function test_mlsadf_synthesis(; order=25, savepath="test16k_mlsadf.wav")
     println("testing: mlsadf_synthesis")
     α = mcepalpha(fs) # automatic α selection
     mc = estimate(MelCepstrum(order, α), xw)
-
-    f = MLSADF(order, α)
-    y = synthesis!(f, base_excitation, mc, hopsize)
+    y = synthesis(base_excitation, mc, hopsize)
     wavwrite(y, savepath; Fs=fs)
     println("Dumped to $savepath")
 end
@@ -103,10 +93,7 @@ function test_mglsadf_synthesis(; order=25, nstage=6,
     α = mcepalpha(fs)
     γ = -1./nstage
     mgc = estimate(MelGeneralizedCepstrum(order, α, γ), xw)
-
-    # waveform synthesis
-    f = MGLSADF(order, α, nstage)
-    y = synthesis!(f, base_excitation, mgc, hopsize)
+    y = synthesis(base_excitation, mgc, hopsize)
     wavwrite(y, savepath; Fs=fs)
     println("Dumped to $savepath")
 end

--- a/src/SynthesisFilters.jl
+++ b/src/SynthesisFilters.jl
@@ -13,23 +13,26 @@ export
     LinearPredictionVariantsSynthesisFilter, # AllPoleDF
 
     # Speech waveform synthesis filters
-    AllPoleDF,            # All Pole Digital filter
-    AllPoleLatticeDF,     # All Pole Lattice Digital filter
-    LSPDF,                # Line Spectral Pair  Digital Filter
-    LMADF,                # Log Magnitude Approximation Digital Filter
-    MLSADF,               # Mel-Log Spectrum Approximation Digital Filter
-    MGLSADF,              # Mel Generalized-Log Spectrum Approximation Digital Filter
+    AllPoleDF,            # All-pole digital filter for synthesis from LPC
+    AllPoleLatticeDF,     # All-pole lattice digital filter for synthesis from PARCOR
+    LSPDF,                # LSP digital filter for synthesis from LSP
+    LMADF,                # Log magnitude approximation digital filter for synthesis from cepstrum
+    MLSADF,               # Mel-log spectrum approximation digital filter for synthesis from mel-cepstrum
+    MGLSADF,              # Mel generalized-log spectrum approximation digital filter for synthesis from mel-generalized cepstrum
 
-    # high-level interface for waveform synthesis
-    synthesis!,           #
-    synthesis_one_frame!, #
+    # High-level interface for waveform synthesis
+    synthesis,
+    synthesis!,
+    synthesis_one_frame!,
 
-    to_filtcoef,          # spectral parameter to filter coefficients
     filt!,                # filtering one sample
+    to_filtcoef,          # spectral parameter to filter coefficients
 
-    allpass_alpha,        # all-pass constant (alpha)
-    glog_gamma,           # parameter of generalized log function
+    # Mel-generalized cepstrum synthesis filter properties
+    allpass_alpha,        # all-pass constant (α)
+    glog_gamma,           # parameter of generalized log function (γ)
 
+    # MGLSADF property
     nstage                # -1/γ; number of stages for MGLSADF
 
 for fname in [
@@ -40,7 +43,8 @@ for fname in [
               "lspdf",
               "lmadf",
               "mlsadf",
-              "mglsadf"
+              "mglsadf",
+              "helper"
     ]
     include(string(fname, ".jl"))
 end

--- a/src/helper.jl
+++ b/src/helper.jl
@@ -1,0 +1,56 @@
+# high-level interface
+
+### Synthesis for LPC variants ###
+
+function synthesis(excitation::AbstractVector,
+                   param::SpectralParamState{LinearPredictionCoef},
+                   hopsize::Integer)
+    f = AllPoleDF(param_order(paramdef(param)))
+    synthesis!(f, excitation, to_filtcoef(f, param), hopsize)
+end
+
+function synthesis(excitation::AbstractVector,
+                   param::SpectralParamState{PartialAutoCorrelation},
+                   hopsize::Integer)
+    f = AllPoleLatticeDF(param_order(paramdef(param)))
+    synthesis!(f, excitation, to_filtcoef(f, param), hopsize)
+end
+
+function synthesis(excitation::AbstractVector,
+                   param::SpectralParamState{LineSpectralPair},
+                   hopsize::Integer)
+    f = LSPDF(param_order(paramdef(param)))
+    synthesis!(f, excitation, to_filtcoef(f, param), hopsize)
+end
+
+### Synthesis for mel-generalized cepstrums
+
+function synthesis{T<:MelGeneralizedCepstrum}(excitation::AbstractVector,
+                                              param::SpectralParamState{T},
+                                              hopsize::Integer)
+    def = paramdef(param)
+    ns = try
+        # InexactError could happen
+        convert(Int, -1/glog_gamma(def))
+    catch e
+        ns = -1/glog_gamma(def)
+        error("-1/γ must be able to convert to Int, but got $(ns)")
+    end
+    f = MGLSADF(param_order(def), allpass_alpha(def), ns)
+    synthesis!(f, excitation, to_filtcoef(f, param), hopsize)
+end
+
+function synthesis(excitation::AbstractVector,
+                   param::SpectralParamState{MelCepstrum},
+                   hopsize::Integer)
+    def = paramdef(param)
+    f = MLSADF(param_order(def), allpass_alpha(def))
+    synthesis!(f, excitation, to_filtcoef(f, param), hopsize)
+end
+
+function synthesis(excitation::AbstractVector,
+                   param::SpectralParamState{LinearCepstrum},
+                   hopsize::Integer)
+    f = LMADF(param_order(paramdef(param)))
+    synthesis!(f, excitation, to_filtcoef(f, param), hopsize)
+end


### PR DESCRIPTION
- add `synthesis` function that should dispatch on spectral envelope
  paramter types
- add tests
- modifiy compare_vocoders.jl
## New

``` julia
mc = estimate(MelCepstrum(20, 0.41), xw) # suppose `xw` is a windowed matrix that each column represents a windowed time slice
y = synthesis(excitation, mc, hopsize)
```
## Old

``` julia
mc = estimate(MelCepstrum(20, 0.41), xw) # suppose `xw` is a windowed matrix that each column represents a windowed time slice
f = MLSADF(20, 0.41)
y = synthesis!(f, excitation, mc, hopsize)
```

You don't always need to specily a syntehesis filter. It is property selected by argument types.
